### PR TITLE
Refactor hospital consultant structure

### DIFF
--- a/adk/hospital_consultant/__init__.py
+++ b/adk/hospital_consultant/__init__.py
@@ -1,0 +1,4 @@
+"""Hospital consultant multi-agent package."""
+from .agents.team_lead import run_team_lead
+
+__all__ = ["run_team_lead"]

--- a/adk/hospital_consultant/agents/__init__.py
+++ b/adk/hospital_consultant/agents/__init__.py
@@ -1,0 +1,11 @@
+from .billing import billing_agent
+from .medical_report import medical_report_agent
+from .pricing import pricing_agent
+from .finance import finance_agent
+
+__all__ = [
+    "billing_agent",
+    "medical_report_agent",
+    "pricing_agent",
+    "finance_agent",
+]

--- a/adk/hospital_consultant/agents/billing.py
+++ b/adk/hospital_consultant/agents/billing.py
@@ -1,0 +1,10 @@
+from google.adk.agents import Agent
+from ..utils import query_graphql
+
+billing_agent = Agent(
+    name="billing_agent",
+    model="gemini-2.0-flash",
+    description="Handles billing inquiries and insurance claims.",
+    instruction="You respond to billing and insurance related questions using the hospital data graph.",
+    tools=[query_graphql],
+)

--- a/adk/hospital_consultant/agents/finance.py
+++ b/adk/hospital_consultant/agents/finance.py
@@ -1,0 +1,10 @@
+from google.adk.agents import Agent
+from ..utils import query_graphql
+
+finance_agent = Agent(
+    name="finance_agent",
+    model="gemini-2.0-flash",
+    description="Gives financial analysis and statistics.",
+    instruction="Use hospital finance data to answer user questions via GraphQL.",
+    tools=[query_graphql],
+)

--- a/adk/hospital_consultant/agents/medical_report.py
+++ b/adk/hospital_consultant/agents/medical_report.py
@@ -1,0 +1,10 @@
+from google.adk.agents import Agent
+from ..utils import query_graphql
+
+medical_report_agent = Agent(
+    name="medical_report_agent",
+    model="gemini-2.0-flash",
+    description="Specialist in medical reports and patient records.",
+    instruction="Answer questions about medical reports or records. Use the GraphQL API for data.",
+    tools=[query_graphql],
+)

--- a/adk/hospital_consultant/agents/pricing.py
+++ b/adk/hospital_consultant/agents/pricing.py
@@ -1,0 +1,10 @@
+from google.adk.agents import Agent
+from ..utils import query_graphql
+
+pricing_agent = Agent(
+    name="pricing_agent",
+    model="gemini-2.0-flash",
+    description="Provides information on pricing and cost estimates.",
+    instruction="Provide pricing information by querying the GraphQL API.",
+    tools=[query_graphql],
+)

--- a/adk/hospital_consultant/agents/team_lead.py
+++ b/adk/hospital_consultant/agents/team_lead.py
@@ -1,0 +1,42 @@
+"""Team lead agent coordinating hospital consultant specialists."""
+from google.adk.agents import Agent
+
+from .billing import billing_agent
+from .medical_report import medical_report_agent
+from .pricing import pricing_agent
+from .finance import finance_agent
+
+
+def _create_team_lead() -> Agent:
+    """Factory for the team lead agent."""
+    return Agent(
+        name="hospital_team_lead",
+        model="gemini-2.0-flash",
+        description="Coordinator for hospital and insurance queries.",
+        instruction=(
+            "You are the team lead for a group of specialist agents. Assess the user's request "
+            "and delegate to the appropriate agent. Use billing_agent for billing questions, "
+            "medical_report_agent for medical reports, pricing_agent for pricing, and finance_agent for finance."
+        ),
+        tools=[
+            billing_agent,
+            medical_report_agent,
+            pricing_agent,
+            finance_agent,
+        ],
+    )
+
+
+def run_team_lead(user_input: str):
+    """Simple delegation logic based on keywords."""
+    team_lead = _create_team_lead()
+    lower = user_input.lower()
+    if any(word in lower for word in ["bill", "invoice", "claim"]):
+        return billing_agent(user_input)
+    if any(word in lower for word in ["report", "record"]):
+        return medical_report_agent(user_input)
+    if "price" in lower or "cost" in lower:
+        return pricing_agent(user_input)
+    if "finance" in lower or "budget" in lower:
+        return finance_agent(user_input)
+    return team_lead(user_input)

--- a/adk/hospital_consultant/utils.py
+++ b/adk/hospital_consultant/utils.py
@@ -1,0 +1,11 @@
+import requests
+
+GRAPHQL_ENDPOINT = "http://localhost:4000/"
+
+
+def query_graphql(query: str) -> dict:
+    """Send a GraphQL query to the mocked API and return the JSON response."""
+    response = requests.post(GRAPHQL_ENDPOINT, json={"query": query})
+    if response.status_code == 200:
+        return {"status": "success", "data": response.json()}
+    return {"status": "error", "error_message": response.text}


### PR DESCRIPTION
## Summary
- break up hospital consultant agents into a package
- add separate modules for billing, medical reports, pricing, and finance
- create a team_lead module that delegates to the specialist agents
- expose `run_team_lead` from the package

## Testing
- `npm test --prefix graphql`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_683e2b563ce883308509b298fdc8db86