### PR TITLE
Add context store and structured team lead responses

### DIFF
--- a/adk/hospital_consultant/__init__.py
+++ b/adk/hospital_consultant/__init__.py
@@ -1,0 +1,5 @@
+"""Hospital consultant multi-agent package."""
+from .agents.team_lead import run_team_lead
+from .context import context_store
+
+__all__ = ["run_team_lead", "context_store"]

--- a/adk/hospital_consultant/agents/__init__.py
+++ b/adk/hospital_consultant/agents/__init__.py
@@ -1,0 +1,11 @@
+from .billing import billing_agent
+from .medical_report import medical_report_agent
+from .pricing import pricing_agent
+from .finance import finance_agent
+
+__all__ = [
+    "billing_agent",
+    "medical_report_agent",
+    "pricing_agent",
+    "finance_agent",
+]

--- a/adk/hospital_consultant/agents/billing.py
+++ b/adk/hospital_consultant/agents/billing.py
@@ -1,0 +1,10 @@
+from google.adk.agents import Agent
+from ..utils import query_graphql
+
+billing_agent = Agent(
+    name="billing_agent",
+    model="gemini-2.0-flash",
+    description="Handles billing inquiries and insurance claims.",
+    instruction="You respond to billing and insurance related questions using the hospital data graph.",
+    tools=[query_graphql],
+)

--- a/adk/hospital_consultant/agents/finance.py
+++ b/adk/hospital_consultant/agents/finance.py
@@ -1,0 +1,10 @@
+from google.adk.agents import Agent
+from ..utils import query_graphql
+
+finance_agent = Agent(
+    name="finance_agent",
+    model="gemini-2.0-flash",
+    description="Gives financial analysis and statistics.",
+    instruction="Use hospital finance data to answer user questions via GraphQL.",
+    tools=[query_graphql],
+)

--- a/adk/hospital_consultant/agents/medical_report.py
+++ b/adk/hospital_consultant/agents/medical_report.py
@@ -1,0 +1,10 @@
+from google.adk.agents import Agent
+from ..utils import query_graphql
+
+medical_report_agent = Agent(
+    name="medical_report_agent",
+    model="gemini-2.0-flash",
+    description="Specialist in medical reports and patient records.",
+    instruction="Answer questions about medical reports or records. Use the GraphQL API for data.",
+    tools=[query_graphql],
+)

--- a/adk/hospital_consultant/agents/pricing.py
+++ b/adk/hospital_consultant/agents/pricing.py
@@ -1,0 +1,10 @@
+from google.adk.agents import Agent
+from ..utils import query_graphql
+
+pricing_agent = Agent(
+    name="pricing_agent",
+    model="gemini-2.0-flash",
+    description="Provides information on pricing and cost estimates.",
+    instruction="Provide pricing information by querying the GraphQL API.",
+    tools=[query_graphql],
+)

--- a/adk/hospital_consultant/agents/team_lead.py
+++ b/adk/hospital_consultant/agents/team_lead.py
@@ -1,0 +1,61 @@
+"""Team lead agent coordinating hospital consultant specialists."""
+from google.adk.agents import Agent
+
+from .billing import billing_agent
+from .medical_report import medical_report_agent
+from .pricing import pricing_agent
+from .finance import finance_agent
+from ..context import context_store
+
+
+def _create_team_lead() -> Agent:
+    """Factory for the team lead agent."""
+    return Agent(
+        name="hospital_team_lead",
+        model="gemini-2.0-flash",
+        description="Coordinator for hospital and insurance queries.",
+        instruction=(
+            "You are the team lead for a group of specialist agents. Assess the user's request "
+            "and delegate to the appropriate agent. Use billing_agent for billing questions, "
+            "medical_report_agent for medical reports, pricing_agent for pricing, and finance_agent for finance."
+        ),
+        tools=[
+            billing_agent,
+            medical_report_agent,
+            pricing_agent,
+            finance_agent,
+        ],
+    )
+
+
+def _structured(agent_name: str, result: str) -> dict:
+    """Return a basic structured payload for users."""
+    return {"agent": agent_name, "result": result}
+
+
+def run_team_lead(company_id: str, user_id: str, user_input: str) -> dict:
+    """Delegate to a specialist agent and return a structured result."""
+    team_lead = _create_team_lead()
+    lower = user_input.lower()
+    context_store.add_user_message(company_id, user_id, f"user: {user_input}")
+
+    if any(word in lower for word in ["bill", "invoice", "claim"]):
+        result = billing_agent(user_input)
+        context_store.add_user_message(company_id, user_id, f"billing_agent: {result}")
+        return _structured("billing_agent", result)
+    if any(word in lower for word in ["report", "record"]):
+        result = medical_report_agent(user_input)
+        context_store.add_user_message(company_id, user_id, f"medical_report_agent: {result}")
+        return _structured("medical_report_agent", result)
+    if "price" in lower or "cost" in lower:
+        result = pricing_agent(user_input)
+        context_store.add_user_message(company_id, user_id, f"pricing_agent: {result}")
+        return _structured("pricing_agent", result)
+    if "finance" in lower or "budget" in lower:
+        result = finance_agent(user_input)
+        context_store.add_user_message(company_id, user_id, f"finance_agent: {result}")
+        return _structured("finance_agent", result)
+
+    result = team_lead(user_input)
+    context_store.add_user_message(company_id, user_id, f"team_lead: {result}")
+    return _structured("team_lead", result)

--- a/adk/hospital_consultant/context.py
+++ b/adk/hospital_consultant/context.py
@@ -1,0 +1,28 @@
+class InMemoryContextStore:
+    """Simple in-memory context store for demonstration.
+
+    Stores per-company shared context and per-user chat history. In a real
+    application this would be persisted in a database or other storage.
+    """
+
+    def __init__(self):
+        self.company_context = {}
+        self.user_history = {}
+
+    # Company context
+    def set_company_context(self, company_id: str, context: dict) -> None:
+        self.company_context[company_id] = context
+
+    def get_company_context(self, company_id: str) -> dict:
+        return self.company_context.get(company_id, {})
+
+    # User chat history
+    def add_user_message(self, company_id: str, user_id: str, message: str) -> None:
+        self.user_history.setdefault((company_id, user_id), []).append(message)
+
+    def get_user_history(self, company_id: str, user_id: str):
+        return self.user_history.get((company_id, user_id), [])
+
+
+# Singleton instance used by the agents
+context_store = InMemoryContextStore()

--- a/adk/hospital_consultant/utils.py
+++ b/adk/hospital_consultant/utils.py
@@ -1,0 +1,11 @@
+import requests
+
+GRAPHQL_ENDPOINT = "http://localhost:4000/"
+
+
+def query_graphql(query: str) -> dict:
+    """Send a GraphQL query to the mocked API and return the JSON response."""
+    response = requests.post(GRAPHQL_ENDPOINT, json={"query": query})
+    if response.status_code == 200:
+        return {"status": "success", "data": response.json()}
+    return {"status": "error", "error_message": response.text}


### PR DESCRIPTION
## Summary
- export context store from package
- implement in-memory context store for user/company info
- return structured data from the team lead
- log chat messages to the context store

## Testing
- `npm test --prefix graphql`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_683e2b563ce883308509b298fdc8db86