### PR TITLE
Add simple web UI with CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.env*
 
 **node_modules**
+__pycache__/

--- a/adk/__init__.py
+++ b/adk/__init__.py
@@ -1,0 +1,14 @@
+"""Top-level ADK package with optional helper imports."""
+
+# Lazy accessors to avoid heavy imports when the package is only used for CLI
+
+def run_team_lead(*args, **kwargs):
+    from .hospital_consultant import run_team_lead as _run
+    return _run(*args, **kwargs)
+
+
+def get_context_store():
+    from .hospital_consultant import context_store
+    return context_store
+
+__all__ = ["run_team_lead", "get_context_store"]

--- a/adk/cli.py
+++ b/adk/cli.py
@@ -1,0 +1,37 @@
+"""Command line interface for the ADK demo project."""
+
+from __future__ import annotations
+
+import argparse
+import threading
+import webbrowser
+
+
+def web_command(port: int) -> None:
+    """Run the web server and open a browser."""
+    url = f"http://localhost:{port}/"
+
+    def open_browser() -> None:
+        webbrowser.open(url)
+
+    threading.Timer(1.0, open_browser).start()
+
+    from adk.webapp import app  # Import here to avoid heavy deps on CLI startup
+    app.run(host="0.0.0.0", port=port)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="ADK demonstration commands")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    web_parser = sub.add_parser("web", help="Launch the local web chat interface")
+    web_parser.add_argument("--port", type=int, default=8000, help="Port to listen on")
+
+    args = parser.parse_args()
+
+    if args.command == "web":
+        web_command(args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/adk/templates/chat.html
+++ b/adk/templates/chat.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+<head>
+    <title>Chat - {{ lead }}</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        .history { border: 1px solid #ccc; padding: 1em; height: 300px; overflow-y: scroll; }
+        .user { color: #333; margin-bottom: 0.5em; }
+        .agent { color: #006400; margin-bottom: 0.5em; }
+        form { margin-top: 1em; }
+        input[type=text] { width: 80%; padding: 0.5em; }
+        input[type=submit] { padding: 0.5em 1em; }
+    </style>
+</head>
+<body>
+    <h1>{{ lead }}</h1>
+    <div class="history">
+        {% for msg in history %}
+        <div class="{{ 'user' if msg.startswith('user:') else 'agent' }}">{{ msg }}</div>
+        {% endfor %}
+    </div>
+    <form method="post">
+        <input type="text" name="message" autofocus placeholder="Enter your message" required />
+        <input type="submit" value="Send" />
+    </form>
+    <p><a href="{{ url_for('select_team_lead') }}">Back</a></p>
+</body>
+</html>

--- a/adk/templates/select_lead.html
+++ b/adk/templates/select_lead.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+    <title>Select Team Lead</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        .lead-list { list-style: none; padding: 0; }
+        .lead-item { margin: 1em 0; }
+        a { text-decoration: none; font-weight: bold; color: #336699; }
+    </style>
+</head>
+<body>
+    <h1>Select a Team Lead</h1>
+    <ul class="lead-list">
+        {% for key, lead in team_leads.items() %}
+        <li class="lead-item"><a href="{{ url_for('chat', lead=key) }}">{{ lead.name }}</a></li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/adk/webapp.py
+++ b/adk/webapp.py
@@ -1,0 +1,44 @@
+"""Flask web interface for interacting with the team lead agent."""
+
+from __future__ import annotations
+
+from flask import Flask, render_template, request, redirect, url_for
+
+from .hospital_consultant import run_team_lead, context_store
+
+app = Flask(__name__)
+
+# Available team leads could be extended in the future
+TEAM_LEADS = {
+    "hospital": {
+        "name": "Hospital Consultant Team Lead",
+        "runner": run_team_lead,
+    }
+}
+
+COMPANY_ID = "demo_company"
+USER_ID = "demo_user"
+
+
+@app.route("/")
+def select_team_lead():
+    """Homepage for selecting which team lead to chat with."""
+    return render_template("select_lead.html", team_leads=TEAM_LEADS)
+
+
+@app.route("/chat/<lead>", methods=["GET", "POST"])
+def chat(lead: str):
+    """Chat page for the given team lead."""
+    if lead not in TEAM_LEADS:
+        return "Unknown team lead", 404
+
+    if request.method == "POST":
+        message = request.form.get("message", "")
+        if message:
+            TEAM_LEADS[lead]["runner"](COMPANY_ID, USER_ID, message)
+        return redirect(url_for("chat", lead=lead))
+
+    history = context_store.get_user_history(COMPANY_ID, USER_ID)
+    return render_template(
+        "chat.html", lead=TEAM_LEADS[lead]["name"], history=history
+    )


### PR DESCRIPTION
## Summary
- create top level `adk` package
- add flask webapp to chat with the team lead agent
- implement `adk` CLI with `web` subcommand to launch the web UI
- ignore `__pycache__`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `(cd graphql && npm test)`
- `python -m adk.cli --help`

------
https://chatgpt.com/codex/tasks/task_b_683e325bd44c83309cecf206853ce5bb